### PR TITLE
Move from DockerHub to GitHub Container Registry

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: Github-CR
+    branches: main
 
 jobs:
   build_and_push:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: main
+    branches: Github-CR
 
 jobs:
   build_and_push:
@@ -12,16 +12,17 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v1 
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: nistei/fbw-api:latest
+          tags: ghcr.io/${{ github.repository }}:latest
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - 443:443
 
   fbw_api:
-    image: nistei/fbw-api:latest
+    image: ghcr.io/flybywiresim/api:latest
     container_name: fbw_api
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Changes the main/push workflow to push the container images to GHCR instead of DockerHub.

To get this working we need a personal access token with the 'write:packages' scope. The token has to be stored in the repository secrets.
After the image repository is created we can link it to the code repository: https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image