### PR TITLE
Fix empty METAR responses from Vatsim

### DIFF
--- a/src/metar/metar.service.ts
+++ b/src/metar/metar.service.ts
@@ -37,6 +37,10 @@ export class MetarService {
       .pipe(
         tap(response => this.logger.debug(`Response status ${response.status} for Vatsim METAR request`)),
         map(response => {
+          if (!response.data) {
+            throw this.generateNotAvailableException('Empty response', icao);
+          }
+
           return { icao: icao, metar: response.data, source: 'Vatsim' };
         }),
         catchError(


### PR DESCRIPTION
Vatsim responses can return 200 but are still empty. This throws a not-available-error whenever it happens.