### PR TITLE
Implement banned flights

### DIFF
--- a/src/telex/banned-flight-numbers.ts
+++ b/src/telex/banned-flight-numbers.ts
@@ -1,0 +1,8 @@
+export const BannedFlightNumbers = [
+  'AAL11',
+  'AAL77',
+  'MH17',
+  'MH370',
+  'UA93',
+  'UA175',
+];


### PR DESCRIPTION
Implements a basic list of banned flight numbers.
I decided to do it as a file instead of DB so we can use PRs to add prohibited flight numbers.
I also changed the error for existing flights from 400 to 409 (conflict). This allows us to identify if the flight number is taken or prohibited. This does not change the current behavior in the plane itself.
The list is from [Vatstim](vatsim.net/restricted-callsigns)