### PR TITLE
Add profanity extensions

### DIFF
--- a/src/telex/filters.ts
+++ b/src/telex/filters.ts
@@ -6,3 +6,6 @@ export const BannedFlightNumbers = [
   'UA93',
   'UA175',
 ];
+
+export const MessageFilters = [
+];

--- a/src/telex/telex-message.entity.ts
+++ b/src/telex/telex-message.entity.ts
@@ -21,6 +21,10 @@ export class TelexMessage {
   @ApiProperty({ description: 'The message to send', example: 'Hello over there!' })
   message: string;
 
+  @Column()
+  @ApiProperty({ description: 'Whether the message contains profanity and got filtered' })
+  isProfane: boolean;
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   @ManyToOne(type => TelexConnection, x => x.id, { eager: true })
   @ApiProperty({ description: 'The sender connection' })


### PR DESCRIPTION
When sending the message `isProfane` is being evaluated and stored in the DB. This way we can find all profanities easily. When fetching the messages every message gets sent through the filter.