### PR TITLE
Additional features for permanent uplink

### DIFF
--- a/src/telex/telex-connection.entity.ts
+++ b/src/telex/telex-connection.entity.ts
@@ -59,6 +59,10 @@ export class TelexConnection {
   @ApiProperty({ description: 'The heading the aircraft in degrees', example: 250.46, minimum: 0, maximum: 360 })
   heading: number;
 
+  @Column()
+  @ApiProperty({ description: 'Whether the user wants to receive freetext messages', example: true })
+  freetextEnabled: boolean;
+
   @Column({ nullable: true })
   @ApiProperty({ description: 'The origin of the flight', example: 'KLAX', required: false })
   origin?: string;
@@ -80,6 +84,13 @@ export class TelexConnectionUpdateDto {
   @IsNotEmpty()
   @ApiProperty({ description: 'The heading the aircraft in degrees', example: 250.46, minimum: 0, maximum: 360 })
   heading: number;
+
+  // Set it to true to support the old MCDU implementation (0.4.1)
+  // 0.4.1 does this check in the frontend
+  // TODO: Remove the default value after 0.5.0 release
+  @IsOptional()
+  @ApiProperty({ description: 'Whether the user wants to receive freetext messages', example: true })
+  freetextEnabled = true;
 
   @IsOptional()
   @ApiProperty({ description: 'The destination of the flight', example: 'KSFO', required: false })

--- a/src/telex/telex-connection.entity.ts
+++ b/src/telex/telex-connection.entity.ts
@@ -84,14 +84,14 @@ export class TelexConnectionUpdateDto {
   @IsOptional()
   @ApiProperty({ description: 'The destination of the flight', example: 'KSFO', required: false })
   destination?: string;
+
+  @IsOptional()
+  @ApiProperty({ description: 'The origin of the flight', example: 'KLAX', required: false })
+  origin?: string;
 }
 
 export class TelexConnectionDto extends TelexConnectionUpdateDto {
   @IsNotEmpty()
   @ApiProperty({ description: 'The flight number', example: 'OS 355' })
   flight: string;
-
-  @IsOptional()
-  @ApiProperty({ description: 'The origin of the flight', example: 'KLAX', required: false })
-  origin?: string;
 }

--- a/src/telex/telex.service.ts
+++ b/src/telex/telex.service.ts
@@ -67,14 +67,7 @@ export class TelexService {
       throw new HttpException(message, 409);
     }
 
-    const newFlight: TelexConnection = {
-      flight: connection.flight,
-      location: connection.location,
-      trueAltitude: connection.trueAltitude,
-      heading: connection.heading,
-      origin: connection.origin,
-      destination: connection.destination,
-    };
+    const newFlight: TelexConnection = {...connection};
 
     this.logger.log(`Registering new flight '${connection.flight}'`);
     await this.connectionRepository.save(newFlight);
@@ -149,7 +142,7 @@ export class TelexService {
       throw new HttpException(message, 404);
     }
 
-    const recipient = await this.connectionRepository.findOne({ flight: dto.to, isActive: true });
+    const recipient = await this.connectionRepository.findOne({ flight: dto.to, isActive: true, freetextEnabled: true });
     if (!recipient) {
       const message = `Active flight '${dto.to}' does not exist`;
       this.logger.error(message);


### PR DESCRIPTION
Users can disable/enable their freetext in the backend.
Also allows for origin/destination change of an existing connection