### PR TITLE
Adds CPDLC proxy to communicate with Hoppies

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,6 +24,8 @@ import { VatsimService } from './utilities/vatsim.service';
 import { AtcService } from './atc/atc.service';
 import { IvaoService } from './utilities/ivao.service';
 import { GnssModule } from './gnss/gnss.module';
+import { CpdlcController } from './cpdlc/cpdlc.controller';
+import { CpdlcService } from './cpdlc/cpdlc.service';
 
 @Module({
     imports: [
@@ -120,8 +122,9 @@ import { GnssModule } from './gnss/gnss.module';
         AtisController,
         TafController,
         AtcController,
+        CpdlcController,
     ],
-    providers: [MetarService, AtisService, TafService, VatsimService, IvaoService, AtcService],
+    providers: [MetarService, AtisService, TafService, VatsimService, IvaoService, AtcService, CpdlcService],
 })
 export class AppModule {
 }

--- a/src/cpdlc/cpdlc.class.ts
+++ b/src/cpdlc/cpdlc.class.ts
@@ -1,9 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class Cpdlc {
-    @ApiProperty({ description: 'The Hoppie logon code', example: 'xxxxxxxxxx' })
-    logon: string;
-
     @ApiProperty({ description: 'The server\'s response', example: 'ok {}', })
     response: string;
 }

--- a/src/cpdlc/cpdlc.class.ts
+++ b/src/cpdlc/cpdlc.class.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class Cpdlc {
+    @ApiProperty({ description: 'The Hoppie logon code', example: 'xxxxxxxxxx' })
+    logon: string;
+
+    @ApiProperty({ description: 'The server\'s response', example: 'ok {}', })
+    response: string;
+}

--- a/src/cpdlc/cpdlc.controller.spec.ts
+++ b/src/cpdlc/cpdlc.controller.spec.ts
@@ -1,0 +1,16 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CpdlcController } from './cpdlc.controller';
+
+describe('CpdlcController', () => {
+    let controller: CpdlcController;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({ controllers: [CpdlcController] }).compile();
+
+        controller = module.get<CpdlcController>(CpdlcController);
+    });
+
+    it('should be defined', () => {
+        expect(controller).toBeDefined();
+    });
+});

--- a/src/cpdlc/cpdlc.controller.ts
+++ b/src/cpdlc/cpdlc.controller.ts
@@ -9,8 +9,8 @@ import { CpdlcService } from './cpdlc.service';
 import { CpdlcMessageDto } from './dto/cpdlc-message.dto';
 import { Cpdlc } from './cpdlc.class';
 
-@ApiTags('CPDLC')
-@Controller('cpdlc')
+@ApiTags('HOPPIE')
+@Controller('hoppie')
 export class CpdlcController {
     constructor(private cpdlc: CpdlcService) {
     }

--- a/src/cpdlc/cpdlc.controller.ts
+++ b/src/cpdlc/cpdlc.controller.ts
@@ -10,7 +10,7 @@ import { CpdlcMessageDto } from './dto/cpdlc-message.dto';
 import { Cpdlc } from './cpdlc.class';
 
 @ApiTags('HOPPIE')
-@Controller('hoppie')
+@Controller('api/v1/hoppie')
 export class CpdlcController {
     constructor(private cpdlc: CpdlcService) {
     }

--- a/src/cpdlc/cpdlc.controller.ts
+++ b/src/cpdlc/cpdlc.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import {
+    ApiBody,
+    ApiCreatedResponse,
+    ApiNotFoundResponse,
+    ApiTags,
+} from '@nestjs/swagger';
+import { CpdlcService } from './cpdlc.service';
+import { CpdlcMessageDto } from './dto/cpdlc-message.dto';
+import { Cpdlc } from './cpdlc.class';
+
+@ApiTags('CPDLC')
+@Controller('cpdlc')
+export class CpdlcController {
+    constructor(private cpdlc: CpdlcService) {
+    }
+
+  @Post()
+  @ApiBody({ description: 'The message to send', type: CpdlcMessageDto })
+  @ApiCreatedResponse({ description: 'The message could be addressed', type: Cpdlc })
+  @ApiNotFoundResponse({ description: 'The sender or recipient flight number could not be found' })
+    async requestData(@Body() body: CpdlcMessageDto): Promise<Cpdlc> {
+        return this.cpdlc.getData(body);
+    }
+}

--- a/src/cpdlc/cpdlc.controller.ts
+++ b/src/cpdlc/cpdlc.controller.ts
@@ -15,10 +15,10 @@ export class CpdlcController {
     constructor(private cpdlc: CpdlcService) {
     }
 
-  @Post()
-  @ApiBody({ description: 'The message to send', type: CpdlcMessageDto })
-  @ApiCreatedResponse({ description: 'The message could be addressed', type: Cpdlc })
-  @ApiNotFoundResponse({ description: 'The sender or recipient flight number could not be found' })
+    @Post()
+    @ApiBody({ description: 'The message to send', type: CpdlcMessageDto })
+    @ApiCreatedResponse({ description: 'The message could be addressed', type: Cpdlc })
+    @ApiNotFoundResponse({ description: 'The sender or recipient flight number could not be found' })
     async requestData(@Body() body: CpdlcMessageDto): Promise<Cpdlc> {
         return this.cpdlc.getData(body);
     }

--- a/src/cpdlc/cpdlc.service.spec.ts
+++ b/src/cpdlc/cpdlc.service.spec.ts
@@ -1,0 +1,16 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CpdlcService } from './cpdlc.service';
+
+describe('CpdlcService', () => {
+    let service: CpdlcService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({ providers: [CpdlcService] }).compile();
+
+        service = module.get<CpdlcService>(CpdlcService);
+    });
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+});

--- a/src/cpdlc/cpdlc.service.ts
+++ b/src/cpdlc/cpdlc.service.ts
@@ -1,0 +1,47 @@
+import {
+    HttpException,
+    HttpService,
+    Injectable, Logger,
+} from '@nestjs/common';
+import { catchError, map, tap } from 'rxjs/operators';
+import { Cpdlc } from './cpdlc.class';
+import { CacheService } from '../cache/cache.service';
+import { CpdlcMessageDto } from './dto/cpdlc-message.dto';
+
+@Injectable()
+export class CpdlcService {
+  private readonly logger = new Logger(CpdlcService.name);
+
+  constructor(private http: HttpService,
+              private readonly cache: CacheService) {
+  }
+
+  async getData(dto: CpdlcMessageDto): Promise<Cpdlc> {
+      this.logger.debug(`Requesting ${dto.type} for ${dto.from}`);
+
+      const packet = `${dto.packet !== undefined ? `&packet=${encodeURIComponent(dto.packet)}`: ''}`;
+      return this.http.get<string>(`http://www.hoppie.nl/acars/system/connect.html?logon=${dto.logon}&from=${dto.from}&to=${dto.to}&type=${dto.type}${packet}`)
+          .pipe(
+              tap((response) => this.logger.debug(`Response status ${response.status} for Hoppie request request`)),
+              map((response) => {
+                  if (!response.data) {
+                      throw this.generateNotAvailableException('Empty response');
+                  }
+
+                  return { logon: dto.logon, response: response.data };
+              }),
+              catchError(
+                  (err) => {
+                      throw this.generateNotAvailableException(err);
+                  },
+              ),
+          ).toPromise();
+  }
+
+  private generateNotAvailableException(err: any): HttpException {
+      const exception = new HttpException('error {}', 404);
+      this.logger.error(err);
+      this.logger.error(exception);
+      return exception;
+  }
+}

--- a/src/cpdlc/cpdlc.service.ts
+++ b/src/cpdlc/cpdlc.service.ts
@@ -17,12 +17,9 @@ export class CpdlcService {
   }
 
   async getData(dto: CpdlcMessageDto): Promise<Cpdlc> {
-      this.logger.debug(`Requesting ${dto.type} for ${dto.from}`);
-
       const packet = `${dto.packet !== undefined ? `&packet=${encodeURIComponent(dto.packet)}`: ''}`;
       return this.http.get<string>(`http://www.hoppie.nl/acars/system/connect.html?logon=${dto.logon}&from=${dto.from}&to=${dto.to}&type=${dto.type}${packet}`)
           .pipe(
-              tap((response) => this.logger.debug(`Response status ${response.status} for Hoppie request request`)),
               map((response) => {
                   if (!response.data) {
                       throw this.generateNotAvailableException('Empty response');

--- a/src/cpdlc/cpdlc.service.ts
+++ b/src/cpdlc/cpdlc.service.ts
@@ -28,7 +28,7 @@ export class CpdlcService {
                       throw this.generateNotAvailableException('Empty response');
                   }
 
-                  return { logon: dto.logon, response: response.data };
+                  return { response: response.data };
               }),
               catchError(
                   (err) => {

--- a/src/cpdlc/dto/cpdlc-message.dto.ts
+++ b/src/cpdlc/dto/cpdlc-message.dto.ts
@@ -20,5 +20,5 @@ export class CpdlcMessageDto {
 
     @IsOptional()
     @ApiProperty({ description: 'The message content', example: 'data2//1/Hello' })
-    packet: string;
+    packet?: string;
 }

--- a/src/cpdlc/dto/cpdlc-message.dto.ts
+++ b/src/cpdlc/dto/cpdlc-message.dto.ts
@@ -1,0 +1,24 @@
+import { IsNotEmpty, IsOptional } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CpdlcMessageDto {
+    @IsNotEmpty()
+    @ApiProperty({ description: 'The Hoppie logon code', example: 'xxxxxxxxxx' })
+    logon: string;
+
+    @IsNotEmpty()
+    @ApiProperty({ description: 'The from-callsign', example: 'DLH8HM' })
+    from: string;
+
+    @IsNotEmpty()
+    @ApiProperty({ description: 'The to-callsign', example: 'ALL-CALLSIGNS' })
+    to: string
+
+    @IsNotEmpty()
+    @ApiProperty({ description: 'The request type', example: 'poll' })
+    type: string;
+
+    @IsOptional()
+    @ApiProperty({ description: 'The message content', example: 'data2//1/Hello' })
+    packet: string;
+}


### PR DESCRIPTION
Add new /cpdlc-endpoint which forwards POST-requests to hoppie.nl and returns the responses.
All other logic is handled in the A32NX-ATSU system