### PR TITLE
fix: temporarily fallthrough to VATSIM for IVAO METAR

### DIFF
--- a/src/metar/metar.service.ts
+++ b/src/metar/metar.service.ts
@@ -26,8 +26,6 @@ export class MetarService {
           return this.handleVatsim(icaoCode).toPromise();
       case 'ms':
           return this.handleMs(icaoCode);
-      case 'ivao':
-          return this.handleIvao(icaoCode);
       case 'pilotedge':
           return this.handlePilotEdge(icaoCode).toPromise();
       }


### PR DESCRIPTION
IVAO have discontinued their Weather Service (https://wx.ivao.aero/).

This is a temporary measure to give users a VATSIM METAR instead.