### PR TITLE
feat: aviationweather.gov metar + fix taf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "class-validator": "^0.12.2",
         "elastic-apm-node": "^3.9.0",
         "express-rate-limit": "^5.1.3",
-        "fast-xml-parser": "^3.17.4",
         "helmet": "^4.1.1",
         "iconv-lite": "^0.6.2",
         "mysql": "^2.18.1",
@@ -7157,14 +7156,6 @@
       "integrity": "sha512-bI/544WUQlD2iXBibQbOMSmG07Hay7YrpXlKaeGTPT7H7pC0eitt3usak5vUwEvCGK/O7rUAM3iyQValGU22TQ==",
       "dependencies": {
         "end-of-stream": "^1.4.1"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.4.tgz",
-      "integrity": "sha512-qudnQuyYBgnvzf5Lj/yxMcf4L9NcVWihXJg7CiU1L+oUCq8MUnFEfH2/nXR/W5uq+yvUN1h7z6s7vs2v1WkL1A==",
-      "bin": {
-        "xml2js": "cli.js"
       }
     },
     "node_modules/fb-watchman": {
@@ -24131,11 +24122,6 @@
       "requires": {
         "end-of-stream": "^1.4.1"
       }
-    },
-    "fast-xml-parser": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.4.tgz",
-      "integrity": "sha512-qudnQuyYBgnvzf5Lj/yxMcf4L9NcVWihXJg7CiU1L+oUCq8MUnFEfH2/nXR/W5uq+yvUN1h7z6s7vs2v1WkL1A=="
     },
     "fb-watchman": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "class-validator": "^0.12.2",
     "elastic-apm-node": "^3.9.0",
     "express-rate-limit": "^5.1.3",
-    "fast-xml-parser": "^3.17.4",
     "helmet": "^4.1.1",
     "iconv-lite": "^0.6.2",
     "mysql": "^2.18.1",

--- a/src/metar/metar.controller.ts
+++ b/src/metar/metar.controller.ts
@@ -18,7 +18,7 @@ export class MetarController {
       description: 'The source for the METAR',
       example: 'vatsim',
       required: false,
-      enum: ['vatsim', 'ms', 'ivao', 'pilotedge'],
+      enum: ['vatsim', 'ms', 'ivao', 'pilotedge', 'aviationweather'],
   })
   @ApiOkResponse({ description: 'METAR notice was found', type: Metar })
   @ApiNotFoundResponse({ description: 'METAR not available for ICAO' })


### PR DESCRIPTION
aviationweather.gov decommisioned their old API a few days ago. A new richer API is available in it's place https://aviationweather.gov/data/api/#/.

- fix: aviationweather.gov taf
  Fix the TAF service to use the new API. Also remove the `fast-xml-parser` dep as we no longer need it.
- feat: add aviationweather.gov metars
  Add support for fetching METARs from aviationweather.gov with the new API.