### PR TITLE
feat(aoc): AOC Simulation (Part 1)

### DIFF
--- a/src/aoc/aoc-connection.controller.ts
+++ b/src/aoc/aoc-connection.controller.ts
@@ -1,8 +1,15 @@
-import { Body, CacheInterceptor, CacheTTL, Controller, Get, Post, UseInterceptors } from '@nestjs/common';
-import { ApiBadRequestResponse, ApiBody, ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { Body, CacheInterceptor, CacheTTL, Controller, Delete, Get, Param, Post, Put, Query, Request, UseGuards, UseInterceptors, ValidationPipe } from '@nestjs/common';
+import { ApiBadRequestResponse, ApiBody, ApiCreatedResponse, ApiNotFoundResponse, ApiOkResponse, ApiParam, ApiQuery, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { AocService } from './aoc.service';
 import { CreateAocConnectionDto } from './dto/create-aoc-connection.dto';
 import { FlightToken } from '../auth/flights/flight-token.class';
+import { PaginatedAocConnectionDto } from './dto/paginated-aoc-connection.dto';
+import { PaginationDto } from '../common/Pagination';
+import { BoundsDto } from '../common/Bounds';
+import { AocConnectionSearchResultDto } from './dto/aoc-connection-search-result.dto';
+import { AocConnection } from './entities/aoc-connection.entity';
+import { FlightAuthGuard } from '../auth/flights/flight-auth-guard.service';
+import { UpdateAocConnectionDto } from './dto/update-aoc-connection.dto';
 
 @ApiTags('AOC')
 @Controller('aoc')
@@ -11,11 +18,78 @@ export class AocConnectionController {
     constructor(private aoc: AocService) {
     }
 
+    @Get()
+    @CacheTTL(15)
+    @ApiOkResponse({ description: 'The paginated list of connections', type: PaginatedAocConnectionDto })
+    @ApiQuery({
+        name: 'take',
+        type: Number,
+        required: false,
+        description: 'The number of connections to take',
+        schema: { maximum: 25, minimum: 0, default: 25 },
+    })
+    @ApiQuery({
+        name: 'skip',
+        type: Number,
+        required: false,
+        description: 'The number of connections to skip',
+        schema: { minimum: 0, default: 0 },
+    })
+    @ApiQuery({
+        name: 'north',
+        type: Number,
+        required: false,
+        description: 'Latitude for the north edge of the bounding box',
+        schema: { minimum: -90, maximum: 90, default: 90 },
+    })
+    @ApiQuery({
+        name: 'east',
+        type: Number,
+        required: false,
+        description: 'Longitude for the east edge of the bounding box',
+        schema: { minimum: -180, maximum: 180, default: 180 },
+    })
+    @ApiQuery({
+        name: 'south',
+        type: Number,
+        required: false,
+        description: 'Latitude for the south edge of the bounding box',
+        schema: { minimum: -90, maximum: 90, default: -90 },
+    })
+    @ApiQuery({
+        name: 'west',
+        type: Number,
+        required: false,
+        description: 'Longitude for the west edge of the bounding box',
+        schema: { minimum: -180, maximum: 180, default: -180 },
+    })
+    getAllActiveConnections(@Query(new ValidationPipe({ transform: true })) pagination: PaginationDto,
+        @Query(new ValidationPipe({ transform: true })) bounds: BoundsDto): Promise<PaginatedAocConnectionDto> {
+        return this.aoc.getActiveConnections(pagination, bounds);
+    }
+
+    @Get('_find')
+    @CacheTTL(15)
+    @ApiQuery({ name: 'flight', description: 'The flight number', example: 'AAL456' })
+    @ApiOkResponse({ description: 'All connections matching the query', type: AocConnectionSearchResultDto })
+    findConnection(@Query('flight') flight: string): Promise<AocConnectionSearchResultDto> {
+        return this.aoc.findActiveConnectionByFlight(flight);
+    }
+
     @Get('_count')
     @CacheTTL(15)
     @ApiOkResponse({ description: 'The total number of active AOC connections', type: Number })
     countConnections(): Promise<number> {
         return this.aoc.countActiveConnections();
+    }
+
+    @Get(':id')
+    @CacheTTL(15)
+    @ApiParam({ name: 'id', description: 'The connection ID', example: '6571f19e-21f7-4080-b239-c9d649347101' })
+    @ApiOkResponse({ description: 'The connection with the given ID was found', type: AocConnection })
+    @ApiNotFoundResponse({ description: 'The connection with the given ID could not be found' })
+    getSingleConnection(@Param('id') id: string): Promise<AocConnection> {
+        return this.aoc.getSingleConnection(id);
     }
 
     @Post()
@@ -27,5 +101,24 @@ export class AocConnectionController {
     @ApiBadRequestResponse({ description: 'An active flight with the given flight number is already in use' })
     addNewConnection(@Body() body: CreateAocConnectionDto): Promise<FlightToken> {
         return this.aoc.addNewConnection(body);
+    }
+
+    @Put()
+    @UseGuards(FlightAuthGuard)
+    @ApiSecurity('jwt')
+    @ApiBody({ description: 'The updated connection', type: UpdateAocConnectionDto })
+    @ApiOkResponse({ description: 'The connection got updated', type: AocConnection })
+    @ApiNotFoundResponse({ description: 'The connection with the given ID could not be found' })
+    updateConnection(@Body() body: UpdateAocConnectionDto, @Request() req): Promise<AocConnection> {
+        return this.aoc.updateConnection(req.user.connectionId, body);
+    }
+
+    @Delete()
+    @UseGuards(FlightAuthGuard)
+    @ApiSecurity('jwt')
+    @ApiOkResponse({ description: 'The connection got disabled' })
+    @ApiNotFoundResponse({ description: 'The connection with the given ID could not be found' })
+    disableConnection(@Request() req): Promise<void> {
+        return this.aoc.disableConnection(req.user.connectionId);
     }
 }

--- a/src/aoc/aoc-connection.controller.ts
+++ b/src/aoc/aoc-connection.controller.ts
@@ -1,5 +1,5 @@
-import { Body, CacheInterceptor, Controller, Post, UseInterceptors } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { Body, CacheInterceptor, CacheTTL, Controller, Get, Post, UseInterceptors } from '@nestjs/common';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { AocService } from './aoc.service';
 import { CreateAocConnectionDto } from './dto/create-aoc-connection.dto';
 import { FlightToken } from '../auth/flights/flight-token.class';
@@ -9,6 +9,13 @@ import { FlightToken } from '../auth/flights/flight-token.class';
 @UseInterceptors(CacheInterceptor)
 export class AocConnectionController {
     constructor(private aoc: AocService) {
+    }
+
+    @Get('_count')
+    @CacheTTL(15)
+    @ApiOkResponse({ description: 'The total number of active AOC connections', type: Number })
+    countConnections(): Promise<number> {
+        return this.aoc.countActiveConnections();
     }
 
     @Post()

--- a/src/aoc/aoc-connection.controller.ts
+++ b/src/aoc/aoc-connection.controller.ts
@@ -1,5 +1,5 @@
 import { Body, CacheInterceptor, CacheTTL, Controller, Get, Post, UseInterceptors } from '@nestjs/common';
-import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBadRequestResponse, ApiBody, ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { AocService } from './aoc.service';
 import { CreateAocConnectionDto } from './dto/create-aoc-connection.dto';
 import { FlightToken } from '../auth/flights/flight-token.class';
@@ -19,6 +19,12 @@ export class AocConnectionController {
     }
 
     @Post()
+    @ApiBody({
+        description: 'The new connection containing the flight number and current location',
+        type: CreateAocConnectionDto,
+    })
+    @ApiCreatedResponse({ description: 'An AOC connection got created', type: FlightToken })
+    @ApiBadRequestResponse({ description: 'An active flight with the given flight number is already in use' })
     addNewConnection(@Body() body: CreateAocConnectionDto): Promise<FlightToken> {
         return this.aoc.addNewConnection(body);
     }

--- a/src/aoc/aoc-connection.controller.ts
+++ b/src/aoc/aoc-connection.controller.ts
@@ -1,0 +1,18 @@
+import { Body, CacheInterceptor, Controller, Post, UseInterceptors } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { AocService } from './aoc.service';
+import { CreateAocConnectionDto } from './dto/create-aoc-connection.dto';
+import { FlightToken } from '../auth/flights/flight-token.class';
+
+@ApiTags('AOC')
+@Controller('aoc')
+@UseInterceptors(CacheInterceptor)
+export class AocConnectionController {
+    constructor(private aoc: AocService) {
+    }
+
+    @Post()
+    addNewConnection(@Body() body: CreateAocConnectionDto): Promise<FlightToken> {
+        return this.aoc.addNewConnection(body);
+    }
+}

--- a/src/aoc/aoc.module.ts
+++ b/src/aoc/aoc.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AocConnection } from './entities/aoc-connection.entity';
+import { AocConnectionController } from './aoc-connection.controller';
+import { AocService } from './aoc.service';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([AocConnection]),
+        AuthModule,
+    ],
+    providers: [AocService],
+    controllers: [AocConnectionController],
+    exports: [AocService],
+})
+export class AocModule {}

--- a/src/aoc/aoc.service.ts
+++ b/src/aoc/aoc.service.ts
@@ -1,0 +1,67 @@
+import { HttpException, Injectable, Logger } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { Cron } from '@nestjs/schedule';
+import { BannedFlightNumbers } from '../telex/filters';
+import { CreateAocConnectionDto } from './dto/create-aoc-connection.dto';
+import { AuthService } from '../auth/auth.service';
+import { FlightToken } from '../auth/flights/flight-token.class';
+import { AocConnection } from './entities/aoc-connection.entity';
+
+@Injectable()
+export class AocService {
+    private readonly logger = new Logger(AocService.name);
+
+    constructor(
+        @InjectRepository(AocConnection)
+        private readonly connectionRepository: Repository<AocConnection>,
+        private readonly configService: ConfigService,
+        private readonly authService: AuthService,
+    ) {}
+
+    @Cron('*/5 * * * * *')
+    private async checkForStaleConnections() {
+        if (this.configService.get<boolean>('aoc.disableCleanup')) {
+            return;
+        }
+
+        const timeout = this.configService.get<number>('aoc.timeoutMin');
+        this.logger.verbose(`Trying to cleanup stale AOC connections older than ${timeout} minutes`);
+
+        const connections = await this.connectionRepository
+            .createQueryBuilder()
+            .update()
+            .set({ isActive: false })
+            .andWhere(`lastContact < NOW() - INTERVAL ${timeout} MINUTE`)
+            .andWhere('isActive = 1')
+            .execute();
+
+        this.logger.debug(`Set ${connections.affected} state connection to inactive`);
+    }
+
+    async addNewConnection(connection: CreateAocConnectionDto): Promise<FlightToken> {
+        this.logger.log(`Trying to register new AOC connection '${connection.flight}'`);
+
+        if (BannedFlightNumbers.includes(connection.flight.toUpperCase())) {
+            const message = `User tried to use banned flight number: '${connection.flight}'`;
+            this.logger.log(message);
+            throw new HttpException(message, 400);
+        }
+
+        const existingFlight = await this.connectionRepository.findOne({ flight: connection.flight, isActive: true });
+
+        if (existingFlight) {
+            const message = `An active flight with the number '${connection.flight}' is already in use`;
+            this.logger.error(message);
+            throw new HttpException(message, 409);
+        }
+
+        const newFlight: AocConnection = { ...connection };
+
+        this.logger.log(`Registering new flight '${connection.flight}'`);
+        await this.connectionRepository.save(newFlight);
+
+        return this.authService.registerFlight(newFlight.flight, newFlight.id);
+    }
+}

--- a/src/aoc/aoc.service.ts
+++ b/src/aoc/aoc.service.ts
@@ -40,6 +40,12 @@ export class AocService {
         this.logger.debug(`Set ${connections.affected} state connection to inactive`);
     }
 
+    async countActiveConnections(): Promise<number> {
+        this.logger.debug('Trying to get total number of active connections');
+
+        return this.connectionRepository.count({ isActive: true });
+    }
+
     async addNewConnection(connection: CreateAocConnectionDto): Promise<FlightToken> {
         this.logger.log(`Trying to register new AOC connection '${connection.flight}'`);
 

--- a/src/aoc/dto/aoc-connection-search-result.dto.ts
+++ b/src/aoc/dto/aoc-connection-search-result.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AocConnection } from '../entities/aoc-connection.entity';
+
+export class AocConnectionSearchResultDto {
+    @ApiProperty({ description: 'A possible full text match' })
+    fullMatch?: AocConnection;
+
+    @ApiProperty({ description: 'All possible matches', type: [AocConnection] })
+    matches: AocConnection[];
+}

--- a/src/aoc/dto/create-aoc-connection.dto.ts
+++ b/src/aoc/dto/create-aoc-connection.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { UpdateAocConnectionDto } from './update-aoc-connection.dto';
+
+export class CreateAocConnectionDto extends UpdateAocConnectionDto {
+    @IsNotEmpty()
+    @ApiProperty({ description: 'The flight number', example: 'OS355' })
+    flight: string;
+}

--- a/src/aoc/dto/paginated-aoc-connection.dto.ts
+++ b/src/aoc/dto/paginated-aoc-connection.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AocConnection } from '../entities/aoc-connection.entity';
+
+export class PaginatedAocConnectionDto {
+    @ApiProperty({ description: 'List of AOC connections', type: [AocConnection] })
+    results: AocConnection[];
+
+    @ApiProperty({ description: 'Amount of connections returned', example: 25 })
+    count: number;
+
+    @ApiProperty({ description: 'The number of total active connections in the boundary', example: 1237 })
+    total: number;
+}

--- a/src/aoc/dto/update-aoc-connection.dto.ts
+++ b/src/aoc/dto/update-aoc-connection.dto.ts
@@ -3,8 +3,13 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Point } from '../../utilities/point.entity';
 
 export class UpdateAocConnectionDto {
+    @IsOptional()
     @IsNotEmpty()
-    @ApiProperty({ description: 'The current location of the aircraft '})
+    @ApiProperty({ description: 'The flight number', example: 'OS355' })
+    flight: string;
+
+    @IsNotEmpty()
+    @ApiProperty({ description: 'The current location of the aircraft ' })
     location: Point;
 
     @IsNotEmpty()

--- a/src/aoc/dto/update-aoc-connection.dto.ts
+++ b/src/aoc/dto/update-aoc-connection.dto.ts
@@ -3,11 +3,6 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Point } from '../../utilities/point.entity';
 
 export class UpdateAocConnectionDto {
-    @IsOptional()
-    @IsNotEmpty()
-    @ApiProperty({ description: 'The flight number', example: 'OS355' })
-    flight: string;
-
     @IsNotEmpty()
     @ApiProperty({ description: 'The current location of the aircraft ' })
     location: Point;

--- a/src/aoc/dto/update-aoc-connection.dto.ts
+++ b/src/aoc/dto/update-aoc-connection.dto.ts
@@ -17,11 +17,11 @@ export class UpdateAocConnectionDto {
 
     @IsOptional()
     @ApiProperty({ description: 'Whether the user wants to receive freetext messages', example: true })
-    freetextEnabled: boolean;
+    freetextEnabled: boolean = true;
 
     @IsOptional()
     @ApiProperty({ description: 'The aircraft type the connection associated with', example: 'A32NX' })
-    aircraftType = 'unknown';
+    aircraftType: string = 'unknown';
 
     @IsOptional()
     @ApiProperty({ description: 'The destination of the flgiht', example: 'KSFO', required: false })

--- a/src/aoc/dto/update-aoc-connection.dto.ts
+++ b/src/aoc/dto/update-aoc-connection.dto.ts
@@ -1,0 +1,33 @@
+import { IsNotEmpty, IsOptional } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { Point } from '../../utilities/point.entity';
+
+export class UpdateAocConnectionDto {
+    @IsNotEmpty()
+    @ApiProperty({ description: 'The current location of the aircraft '})
+    location: Point;
+
+    @IsNotEmpty()
+    @ApiProperty({ description: 'The altitude above sea level of the aircraft in feet', example: 3500 })
+    trueAltitude: number;
+
+    @IsNotEmpty()
+    @ApiProperty({ description: 'The heading of the aircraft in degrees', example: 250.46, minimum: 0, maximum: 360 })
+    heading: number;
+
+    @IsOptional()
+    @ApiProperty({ description: 'Whether the user wants to receive freetext messages', example: true })
+    freetextEnabled: boolean;
+
+    @IsOptional()
+    @ApiProperty({ description: 'The aircraft type the connection associated with', example: 'A32NX' })
+    aircraftType = 'unknown';
+
+    @IsOptional()
+    @ApiProperty({ description: 'The destination of the flgiht', example: 'KSFO', required: false })
+    destination?: string;
+
+    @IsOptional()
+    @ApiProperty({ description: 'The origin of the flight', example: 'KLAX', required: false })
+    origin?: string;
+}

--- a/src/aoc/entities/aoc-connection.entity.ts
+++ b/src/aoc/entities/aoc-connection.entity.ts
@@ -1,0 +1,72 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { Point } from '../../utilities/point.entity';
+
+@Entity()
+export class AocConnection {
+    @PrimaryGeneratedColumn('uuid')
+    @ApiProperty({
+        description: 'The unique identifier of the connection',
+        example: '6571f19e-21f7-4080-b239-c9d649347101',
+    })
+    id?: string;
+
+    @Column({ default: true })
+    @Index()
+    @ApiProperty({ description: 'Whether the connection is an active one or not' })
+    isActive?: boolean;
+
+    @CreateDateColumn()
+    @Index()
+    @ApiProperty({ description: 'The time of first contact' })
+    firstContact?: Date;
+
+    @UpdateDateColumn()
+    @Index()
+    @ApiProperty({ description: 'The time of last contact' })
+    lastContact?: Date;
+
+    @Column()
+    @Index()
+    @ApiProperty({ description: 'The flight number', example: 'OS355' })
+    flight: string;
+
+    @Column({
+        type: 'point',
+        nullable: false,
+        transformer: {
+            from: (v) => ({
+                x: Number(v.split(' ')[0].slice(6)),
+                y: Number(v.split(' ')[1].slice(0, -1)),
+            }),
+            to: (v) => `POINT(${v.x} ${v.y})`,
+        },
+    })
+    @Index({ spatial: true })
+    @ApiProperty({ description: 'The current location of the aircraft' })
+    location: Point;
+
+    @Column()
+    @ApiProperty({ description: 'The altitude above sea level of the aircraft in feet', example: 3500 })
+    trueAltitude: number;
+
+    @Column()
+    @ApiProperty({ description: 'The heading of the aircraft in degrees', example: 250.46, minimum: 0, maximum: 360 })
+    heading: number;
+
+    @Column()
+    @ApiProperty({ description: 'The aircraft type the connection associated with', example: 'A32NX' })
+    aircraftType: string;
+
+    @Column({ nullable: true })
+    @ApiProperty({ description: 'The origin of the flight', example: 'KLAX', required: false })
+    origin?: string;
+
+    @Column({ nullable: true })
+    @ApiProperty({ description: 'The destination of the flight', example: 'KSFO', required: false })
+    destination?: string;
+
+    @Column()
+    @ApiProperty({ description: 'Whether the user wants to receive freetext messages', example: true })
+    freetextEnabled: boolean;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,6 +28,7 @@ import { GnssModule } from './gnss/gnss.module';
 import { CpdlcController } from './cpdlc/cpdlc.controller';
 import { CpdlcService } from './cpdlc/cpdlc.service';
 import { NotFoundExceptionFilter } from './utilities/not-found.filter';
+import { AocModule } from './aoc/aoc.module';
 
 @Module({
     imports: [
@@ -117,6 +118,7 @@ import { NotFoundExceptionFilter } from './utilities/not-found.filter';
         GitVersionsModule,
         ChartsModule,
         GnssModule,
+        AocModule,
     ],
     controllers: [
         AppController,

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -26,6 +26,10 @@ export default () => ({
         timeoutMin: parseInt(process.env.TELEX_TIMEOUT_MIN) || 6,
         discordWebhook: process.env.TELEX_DISCORD_WEBHOOK || '',
     },
+    aoc: {
+        disableCleanup: envBool('AOC_DISABLE_CLEANUP', true),
+        timeoutMin: parseInt(process.env.AOC_TIMEOUT_MIN) || 6,
+    },
     auth: {
         secret: envOrFile('AUTH_SECRET', './secrets/jwt_secret.txt') || 'FlyByWire',
         expires: process.env.AUTH_EXPIRES || '12h',

--- a/src/utilities/point.entity.ts
+++ b/src/utilities/point.entity.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class Point {
+    @ApiProperty({ description: 'The X coordinate' })
+    x: number;
+
+    @ApiProperty({ description: 'The Y coordinate' })
+    y: number;
+}


### PR DESCRIPTION
This PR is part of a bigger project to implement a full immersive AOC simulation.

Part 1 will consist of the following changes / additions:
- [ ] Implement AOC Connection Endpoints (POST - register, PUT - keepalive)
- [ ] Implement Telex functionality into AOC endpoints (freetext)
- [ ] Add Database Migration to migrate data from Telex Connections -> Aoc Connections & Telex Messages -> Freetext Messages
- [ ] Redirect Old Telex Message Endpoints

Part 2: Implement OOOI Endpoints
Part 3: Implement Init Endpoints

This list is not exhaustive and subject to change.