### PR TITLE
chore: harden docker compose mysql version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - 6379:6379
 
   mysql:
-    image: mysql:latest
+    image: mysql:5.7
     restart: unless-stopped
     command: --default-authentication-plugin=mysql_native_password
     environment:


### PR DESCRIPTION
This PR updates the MySQL version in Docker Compose from `latest` to `5.7`.

#### Reason for Change
- MySQL 8.0 / 9.0 deprecated and removed the `mysql_native_password` plugin, breaking legacy authentication.
- Pinned to 5.7 to ensure compatibility and predictable behavior.

#### Benefits
- Legacy authentication workflows remain functional.
- Avoids issues caused by relying on `latest` for versioning.