### PR TITLE
feat(atis): add atis code

### DIFF
--- a/src/atis/atis.class.ts
+++ b/src/atis/atis.class.ts
@@ -17,9 +17,21 @@ export class Atis {
   })
   combined?: string;
 
+  @ApiProperty({
+      description: 'The combined ATIS code',
+      example: 'V',
+  })
+  combinedCode?: string;
+
   @ApiProperty({ description: 'The arrival ATIS notice' })
   arr?: string;
 
+  @ApiProperty({ description: 'The arrival ATIS code' })
+  arrCode?: string;
+
   @ApiProperty({ description: 'The departure ATIS notice' })
   dep?: string;
+
+  @ApiProperty({ description: 'The departure ATIS code' })
+  depCode?: string;
 }

--- a/src/atis/atis.service.ts
+++ b/src/atis/atis.service.ts
@@ -56,12 +56,9 @@ export class AtisService {
                 };
 
                 response.data.forEach((x) => {
-                    atis[x.type] = x.datis;
+                    atis[x.type] = x.datis.toUpperCase();
+                    atis[`${x.type}Code`] = x.code.toUpperCase(); 
                 });
-
-                atis.dep?.toUpperCase();
-                atis.arr?.toUpperCase();
-                atis.combined?.toUpperCase();
 
                 return atis;
             }),
@@ -76,8 +73,11 @@ export class AtisService {
             .fetchVatsimData()
             .then((response) => {
                 const combined = response.atis.find((x) => x.callsign === `${icao}_ATIS`)?.text_atis.join(' ').toUpperCase();
+                const combinedCode = response.atis.find((x) => x.callsign === `${icao}_ATIS`)?.atis_code.toUpperCase();
                 const arr = response.atis.find((x) => x.callsign === `${icao}_A_ATIS`)?.text_atis.join(' ').toUpperCase();
+                const arrCode = response.atis.find((x) => x.callsign === `${icao}_A_ATIS`)?.atis_code.toUpperCase();
                 const dep = response.atis.find((x) => x.callsign === `${icao}_D_ATIS`)?.text_atis.join(' ').toUpperCase();
+                const depCode = response.atis.find((x) => x.callsign === `${icao}_D_ATIS`)?.atis_code.toUpperCase();
 
                 if (combined === undefined && arr === undefined && dep === undefined) {
                     throw new Error('No ATIS found');
@@ -87,8 +87,11 @@ export class AtisService {
                     icao,
                     source: 'Vatsim',
                     combined,
+                    combinedCode,
                     arr,
+                    arrCode,
                     dep,
+                    depCode,
                 };
             })
             .catch((e) => {
@@ -105,6 +108,9 @@ export class AtisService {
                 combined: response.clients.atcs
                     .find((atc) => atc.callsign.includes(icao.toUpperCase()))
                     ?.atis?.lines.join(' '),
+                combinedCode: response.clients.atcs
+                    .find((atc) => atc.callsign.includes(icao.toUpperCase()))
+                    ?.atis?.revision.toUpperCase(),
             }))
             .catch((e) => {
                 throw this.generateNotAvailableException(e, icao);
@@ -121,10 +127,11 @@ export class AtisService {
                 )),
                 map((response) => ({
                     icao,
-                    source: 'FAA',
+                    source: 'PilotEdge',
                     combined: response.data.text
                         .replace('\n\n', ' ')
                         .toUpperCase(),
+                    combinedCode: response.data.letter.toUpperCase(),
                 })),
                 catchError((err) => {
                     throw this.generateNotAvailableException(err, icao);

--- a/src/utilities/ivao.service.ts
+++ b/src/utilities/ivao.service.ts
@@ -47,7 +47,7 @@ interface Server {
 interface Atis {
     lines: string[];
     callsign: string;
-    revision: number;
+    revision: string;
     timestamp: string;
     sessionId: number;
 }


### PR DESCRIPTION
Add ATIS code as part of the return value for ATIS requests.

In the current implementations, the aircraft has to parse the raw ATIS message to find the ATIS code. This is particularly challenging and inefficient due to the inconsistencies in formatting ATIS messages across different regions and networks.

This ATIS code is available from the endpoints that the FBW API is pulling from but it is not used in the existing implementation. This PR forwards that ATIS code so aircraft no longer need to figure out the ATIS letter code from the raw message anymore. Improving accuracy of the ATIS systems.

This PR extends the existing API by returning three additional optional fields to maintain backwards compatibility with existing API users.

<img width="950" height="585" alt="image" src="https://github.com/user-attachments/assets/11f71584-c8db-4ad4-bfc1-8e4bef5f4e47" />

Additional fixes:

- fix incorrect naming for pilotedge source